### PR TITLE
Try to use newest playlists before getChunks

### DIFF
--- a/TwitterSpace.py
+++ b/TwitterSpace.py
@@ -138,7 +138,7 @@ class TwitterSpace:
         :returns: list of all chunks
         """
         try:
-            TwitterSpace.getPlaylists(dyn_url=playlists.dyn_url)
+            playlists = TwitterSpace.getPlaylists(dyn_url=playlists.dyn_url)
         except Exception:
             pass
         


### PR DESCRIPTION
I encountered a problem that a seemingly working session downloads no file:

```
G:\_temp\tslazer>tslazer --space_id 1DXxyvpBeAWKM --fileformat %St_%Ud
Space Found!
 Space Title: ちょっとだけ雑談🐊🐊⚡️ #源Pスペース
 Space Host Username: genta_5014
 Space Host Display Name: 中村源太🐧
 Space Master URL: https://prod-fastly-ap-northeast-1.video.pscp.tv/Transcoding/v1/hls/FrLi9VfFroqPDu-OkrcRHetOH7vKvcODyvTX5j-SzILYvxu_3nidxAagdDClznAmT44f9ks9ABTA51OQZDg13A/transcode/ap-northeast-1/periscope-replay-direct-prod-ap-northeast-1-public/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsInZlcnNpb24iOiIyIn0.eyJIZWlnaHQiOjgsIkticHMiOjM1MCwiVHJhbnNjb2RlQXVkaW8iOnRydWUsIldpZHRoIjo4fQ.j9A1sJbguxIY34C17U6iN7yTx8JM_ZNYJhfxaSmwGKQ/audio-space/playlist_16762067159899385768.m3u8
 Space Dynamic URL: https://prod-fastly-ap-northeast-1.video.pscp.tv/Transcoding/v1/hls/FrLi9VfFroqPDu-OkrcRHetOH7vKvcODyvTX5j-SzILYvxu_3nidxAagdDClznAmT44f9ks9ABTA51OQZDg13A/non_transcode/ap-northeast-1/periscope-replay-direct-prod-ap-northeast-1-public/audio-space/master_playlist.m3u8
 Chat Token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2ODQ3NjMzMTQsImFtYmlndW91c191c2VyX2lkIjoiZXlKVWQybDBkR1Z5VlhObGNrbGtJam94TmpnME5qYzJPVEUwTkRJNU5qYzNPREo5IiwiYnJvYWRjYXN0X2lkIjoiMURYeHl2cEJlQVdLTSIsImxvd19sYXRlbmN5Ijp0cnVlLCJyZWFkX29ubHkiOmZhbHNlLCJwYXJ0aWNpcGFudF9pbmRleCI6MTYzODExMTAzfQ.wK4oi5D_OGHagVEc_E2JiBG_G9wukpW5IVosY5FvlnQ
 Downloading to ちょっとだけ雑談_源Pスペース_中村源太.m4a
Waiting for space to end...
Space Ended. Now Downloading...
Finished Getting URLs, Waiting for responses
Finished Downloading Chunks
Successfully Downloaded Twitter Space ちょっとだけ雑談_源Pスペース_中村源太.m4a
```


Upon investigation, I find out that the Space Master URL (`/playlist_16762067159899385768.m3u8`) no longer works (returns `NOT FOUND`) while the Space Dynamic URL still works and can give you a new, working Master URL (`/playlist_16762064816429864830.m3u8`). 

The issue seems to be that when downloading from a Space ID once it's ended, in `getChunks()`, while it does try to fetch an updated version of Master URL via `TwitterSpace.getPlaylists(dyn_url=playlists.dyn_url)`, it doesn't update the `playlists` variable. So `m3u8Request = requests.get(playlists.master_url)` later is still using the old, broken `playlists.master_url`.

This PR should fix it.